### PR TITLE
Fix Ubuntu 18.04 Dugite libcurl3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "byline": "^5.0.0",
     "classnames": "^2.2.6",
     "dateformat": "^3.0.3",
-    "dugite": "^1.69.0",
+    "dugite": "1.68.0",
     "electron-compile": "^6.4.2",
     "electron-default-menu": "^1.0.1",
     "electron-devtools-installer": "^2.1.0",


### PR DESCRIPTION
Dugite-Native is not working on latest releases of Linux because of transition from libcurl3 to libcurl4. This issue is still being figured out upstream, downgrading dugite in the meantime.