### PR TITLE
Set a minimum window size

### DIFF
--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -29,7 +29,7 @@ const createWindow = () => {
   // Set window toolbar options
   generateMenu()
 
-  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false, 'minHeight': 300, 'minWidth': 300})
+  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false, "minHeight": 300, "minWidth": 300})
 
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, "../index.html"),

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -29,7 +29,7 @@ const createWindow = () => {
   // Set window toolbar options
   generateMenu()
 
-  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false, "minHeight": 300, "minWidth": 300})
+  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false, minHeight: 300, minWidth: 300})
 
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, "../index.html"),

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -29,7 +29,7 @@ const createWindow = () => {
   // Set window toolbar options
   generateMenu()
 
-  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false})
+  mainWindow = new BrowserWindow({width: 1200, height: 750, titleBarStyle: "hidden", show: false, 'minHeight': 300, 'minWidth': 300})
 
   mainWindow.loadURL(url.format({
     pathname: path.join(__dirname, "../index.html"),


### PR DESCRIPTION
Currently, the application window can be resized and shrunk down almost completely.

![image](https://user-images.githubusercontent.com/16418643/50411460-fd7f5900-07b4-11e9-9411-71e739e995ea.png)

This PR sets the BrowserWindow minimum window size to 300x300, so that it can no longer be shrunk down completely. This value was arbitrarily chosen, and not all elements display as intended at this size, but this was the case beforehand.